### PR TITLE
Fix adminStorageStats auth field name

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -3498,11 +3498,13 @@
   }
 
   async function measureBackendStorageStats() {
+    const session = getRawSession();
+    if (!session) throw new Error('ไม่พบ session');
     const res = await fetch(RESIDENT_AUTH_URL, {
       method: 'POST',
       cache: 'no-store',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ action: 'adminStorageStats', ...getAdminAuth() })
+      body: JSON.stringify({ action: 'adminStorageStats', ...session })
     });
     const data = await res.json().catch(() => ({}));
     if (!res.ok || !data.ok) throw new Error(data.error || 'โหลดไม่สำเร็จ');


### PR DESCRIPTION
## Summary
- The storage-size tab's `adminStorageStats` call was sending `{adminHouseNo, adminPin}`, matching the key names used by other `residentPinAuth` admin actions (`adminAuditLogs`, `adminResidents`)
- `adminStorageStats` instead expects `{houseNo, pin}` — same shape as `adminDocumentVault`/`expenseSession` — so it failed with "Missing houseNo" in production
- Fixed to send `{houseNo, pin}` from the raw resident session, with a guard for a missing/expired session

## Test plan
- [ ] Open `/admin/#storage`, click "🔄 โหลดข้อมูล", confirm the LPR log and Visitor intake rows now show real numbers instead of "อ่านไม่ได้: Missing houseNo"


---
_Generated by [Claude Code](https://claude.ai/code/session_019TLpEfnVtsjet99RX2Vop7)_