### PR TITLE
Fix mobile layout: tab bar wrapping and table column overlap

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -1344,7 +1344,7 @@
       .dashboard > header > div:last-child { width: 100%; justify-content: flex-start; flex-wrap: wrap; }
       .admin-quick-links { width: 100%; }
       .admin-link-btn { flex: 1 1 auto; }
-      .tabs { padding: 14px 16px 0; overflow-x: auto; }
+      .tabs { padding: 14px 16px 0; overflow-x: auto; flex-wrap: nowrap; -webkit-overflow-scrolling: touch; }
       .toolbar { padding: 14px 16px; }
       .table-wrap { margin: 0 16px 16px; }
       .pending-wrap { padding: 6px 16px 24px; grid-template-columns: 1fr; }
@@ -3159,7 +3159,7 @@
 
     el.innerHTML = `
       <div style="overflow-x:auto;">
-        <table style="width:100%;border-collapse:collapse;font-size:.85rem;">
+        <table style="min-width:100%;border-collapse:collapse;font-size:.85rem;">
           <thead>
             <tr style="background:var(--bg);border-bottom:2px solid var(--border);">
               <th style="padding:10px 14px;text-align:left;font-weight:600;white-space:nowrap">เวลา</th>
@@ -3359,7 +3359,7 @@
 
     el.innerHTML = `
       <div style="overflow-x:auto;">
-        <table style="width:100%;border-collapse:collapse;font-size:.85rem;">
+        <table style="min-width:100%;border-collapse:collapse;font-size:.85rem;">
           <thead>
             <tr style="background:var(--bg);border-bottom:2px solid var(--border);">
               <th style="padding:10px 14px;text-align:left;font-weight:600;">บ้าน</th>
@@ -3626,7 +3626,7 @@
 
     contentEl.innerHTML = `
       <div style="overflow-x:auto;">
-        <table style="width:100%;border-collapse:collapse;font-size:.85rem;">
+        <table style="min-width:100%;border-collapse:collapse;font-size:.85rem;">
           <thead>
             <tr style="background:var(--bg);border-bottom:2px solid var(--border);">
               <th style="padding:10px 14px;text-align:left;font-weight:600;">หมวด</th>


### PR DESCRIPTION
## Summary
- Tab bar on mobile: the `max-width:720px` media query set `overflow-x:auto` but never disabled `flex-wrap`, so the tabs still wrapped into a cramped multi-row grid instead of scrolling as a single row. Added `flex-wrap:nowrap` + `-webkit-overflow-scrolling:touch`.
- Activity Log / House Usage / Storage Usage tables: each `<table>` had `width:100%`, which forces the table to squeeze into the narrow mobile viewport instead of growing wider than it. Combined with `white-space:nowrap` on status pills, dates, and house numbers, that made adjacent column content visually bleed into each other on small screens. Switched to `min-width:100%` so the table can exceed its container width when needed, letting the existing `overflow-x:auto` wrapper actually scroll horizontally instead of squashing content.

Reported via screenshots from an iOS Safari session showing the tab grid wrapping oddly and table text overlapping in both the House Usage and Activity Log tabs.

## Test plan
- [ ] On a phone (iOS/Android) or narrow browser width, open `/admin/`, confirm the tab row scrolls horizontally as one line instead of wrapping into a grid
- [ ] Open "การใช้งานบ้าน" (House Usage) tab, confirm status badges and dates no longer overlap and the table scrolls horizontally if needed
- [ ] Open "Activity Log" tab, confirm the house number / time / action columns are legible and don't overlap
- [ ] Open "ขนาดข้อมูล" (Storage Usage) tab, confirm the same
- [ ] Spot-check desktop width still looks unchanged


---
_Generated by [Claude Code](https://claude.ai/code/session_019TLpEfnVtsjet99RX2Vop7)_