### PR TITLE
Actually fix table overlap: override global table-layout:fixed

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -3159,7 +3159,7 @@
 
     el.innerHTML = `
       <div style="overflow-x:auto;">
-        <table style="min-width:100%;border-collapse:collapse;font-size:.85rem;">
+        <table style="width:auto;min-width:100%;table-layout:auto;border-collapse:collapse;font-size:.85rem;">
           <thead>
             <tr style="background:var(--bg);border-bottom:2px solid var(--border);">
               <th style="padding:10px 14px;text-align:left;font-weight:600;white-space:nowrap">เวลา</th>
@@ -3359,7 +3359,7 @@
 
     el.innerHTML = `
       <div style="overflow-x:auto;">
-        <table style="min-width:100%;border-collapse:collapse;font-size:.85rem;">
+        <table style="width:auto;min-width:100%;table-layout:auto;border-collapse:collapse;font-size:.85rem;">
           <thead>
             <tr style="background:var(--bg);border-bottom:2px solid var(--border);">
               <th style="padding:10px 14px;text-align:left;font-weight:600;">บ้าน</th>
@@ -3626,7 +3626,7 @@
 
     contentEl.innerHTML = `
       <div style="overflow-x:auto;">
-        <table style="min-width:100%;border-collapse:collapse;font-size:.85rem;">
+        <table style="width:auto;min-width:100%;table-layout:auto;border-collapse:collapse;font-size:.85rem;">
           <thead>
             <tr style="background:var(--bg);border-bottom:2px solid var(--border);">
               <th style="padding:10px 14px;text-align:left;font-weight:600;">หมวด</th>


### PR DESCRIPTION
## Summary
- Follow-up to #47, which didn't actually fix the mobile table overlap (confirmed via a fresh screenshot after that PR was live)
- Root cause: a global `table { width:100%; table-layout:fixed; }` rule (line ~677) still applied to the Activity Log / House Usage / Storage Usage tables, since the previous fix's inline style never set `width` or `table-layout` — only `min-width`, which is a no-op when `table-layout:fixed` locks columns to an evenly-divided width regardless of content
- With fixed layout, `white-space:nowrap` cells (status pills, dates) don't expand their column or trigger scroll — they just visually spill past their cell boundary into the next column, which is exactly the overlap seen in the screenshots
- Fix: explicitly set `width:auto; table-layout:auto;` inline (keeping `min-width:100%` so it still fills the container on desktop) so columns size by content again and the existing `overflow-x:auto` wrapper can actually scroll horizontally on narrow screens

## Test plan
- [ ] On a phone (or narrow browser width), open "การใช้งานบ้าน" (House Usage), confirm status badges and dates no longer overlap — swipe horizontally to see the full row if needed
- [ ] Same check on "Activity Log" and "ขนาดข้อมูล" (Storage Usage)
- [ ] Confirm desktop width is still unchanged (full table visible without scrolling)


---
_Generated by [Claude Code](https://claude.ai/code/session_019TLpEfnVtsjet99RX2Vop7)_